### PR TITLE
suppress warnings for smartmatch

### DIFF
--- a/LoF.pm
+++ b/LoF.pm
@@ -24,6 +24,7 @@ package LoF;
 
 use strict;
 use warnings;
+no if $] >= 5.018, 'warnings', "experimental::smartmatch";
 
 our $debug;
 


### PR DESCRIPTION
The use of smartmatch and given/when produces warnings with Perl 5.18+. This check suppresses those warnings (currently, nine warnings are generated).

Also, smartmatch was added in Perl v5.10, so it would probably be good to add `use 5.010;` to the top of the module, but I left that for you to decide.
