### PR TITLE
Ancestral allele mismatches

### DIFF
--- a/LoF.pm
+++ b/LoF.pm
@@ -68,7 +68,12 @@ sub new {
     $self->{conservation_file} = $self->{conservation_file} || 'false';
     $self->{conservation_database} = 'false';
     if ($self->{conservation_file} ne 'false') {
-        $self->{conservation_database} = DBI->connect("dbi:SQLite:dbname=" . $self->{conservation_file}, "", "") or die "Cannot connect to " . $self->{conservation_file} . "\n";
+        if ($self->{conservation_file} eq 'mysql') {
+            my $db_info = "DBI:mysql:mysql_read_default_group=loftee;mysql_read_default_file=~/.my.cnf";
+            $self->{conservation_database} = DBI->connect($db_info, undef, undef) or die "Cannot connect to mysql using " . $db_info . "\n";
+        } else {
+            $self->{conservation_database} = DBI->connect("dbi:SQLite:dbname=" . $self->{conservation_file}, "", "") or die "Cannot connect to " . $self->{conservation_file} . "\n";
+        }
     }
     
     $self->{apply_all} = $self->{apply_all} || 'false';

--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ If this flag is set to 'false', the ancestral allele will not be checked and fil
 -   `phylocsf.sql`
 
 The required SQL database (gzip) can be downloaded [here](https://www.broadinstitute.org/~konradk/loftee/phylocsf.sql.gz).
+Alternatively, this can be loaded into MySQL by downloading the source file [here](https://www.broadinstitute.org/~konradk/loftee/phylocsf_data.tsv.gz)
+and loaded into MySQL with the schema available [here](https://www.broadinstitute.org/~konradk/loftee/phylocsf_data_schema.sql).
+You will then need to create a \[loftee\] entry in your `~/.my.cnf` (creating one if it does not exist) that looks like:
+
+<pre>
+[loftee]
+host=your_mysql_host
+user=your_mysql_user
+password=your_mysql_pass
+database=your_mysql_db
+</pre>
 
 -   `check_complete_cds`
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ uses bgzipped inputs for samtools faidx and downloads are available here:
 [https://s3.amazonaws.com/bcbio_nextgen/human_ancestor.fa.gz.gzi](https://s3.amazonaws.com/bcbio_nextgen/human_ancestor.fa.gz.gzi).
 If this flag is set to 'false', the ancestral allele will not be checked and filtered.
 
+-   `phylocsf.sql`
+
+The required SQL database (gzip) can be downloaded [here](https://www.broadinstitute.org/~konradk/loftee/phylocsf.sql.gz).
+
 -   `check_complete_cds`
 
 The Ensembl API contains a "Complete CDS" annotation that indicates that a start and stop codon has been identified for this transcript.

--- a/ancestral.pm
+++ b/ancestral.pm
@@ -1,0 +1,72 @@
+=head1 CONTACT                                                                                                       
+
+ Konrad Karczewski <konradjkarczewski@gmail.com>
+ 
+=cut
+
+=head1 NAME
+
+ ancestral
+
+=head1 SYNOPSIS
+
+ mv ancestral.pm ~/.vep/Plugins
+ perl variant_effect_predictor.pl -i variations.vcf --plugin ancestral
+ perl variant_effect_predictor.pl -i variations.vcf --plugin ancestral,human_ancestor.fa.gz
+
+=head1 DESCRIPTION
+
+ A VEP plugin that writes the ancestral allele from the variant (SNPs only!).
+
+=cut
+
+package ancestral;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
+use Bio::Perl;
+
+sub get_header_info {
+    return {
+        ancestral => "ancestral allele"
+    };
+}
+
+sub feature_types {
+    return ['Feature', 'Intergenic'];
+}
+
+sub new {
+    my $class = shift;
+
+    my $self = $class->SUPER::new(@_);
+    
+    $self->{human_ancestor_fa} = $self->{human_ancestor_fa} || 'human_ancestor.fa.rz';
+    
+    return $self;
+}
+
+sub run {
+    my ($self, $transcript_variation_allele) = @_;
+    my $human_ancestor_location = $self->{human_ancestor_fa};
+    my $variation_feature = $transcript_variation_allele->variation_feature;
+    
+    # Ignoring indels for now
+    if (($variation_feature->allele_string =~ /-/) or (length($variation_feature->allele_string) != 3)) {
+        return {};
+    }
+    
+    # Get ancestral allele from human_ancestor.fa.rz
+    my $region = $variation_feature->seq_region_name() . ":" . $variation_feature->seq_region_start() . '-' . $variation_feature->seq_region_end();
+    my $faidx = `samtools faidx $human_ancestor_location $region`;
+    my @lines = split(/\n/, $faidx);
+    shift @lines;
+    my $ancestral_allele = uc(join('', @lines));
+    
+    return { ancestral => $ancestral_allele };
+}
+
+1;

--- a/ancestral.pm
+++ b/ancestral.pm
@@ -44,6 +44,13 @@ sub new {
 
     my $self = $class->SUPER::new(@_);
     
+    foreach my $parameter (@{$self->params}) {
+        my @param = split /:/, $parameter;
+        if (scalar @param == 2) {
+            $self->{$param[0]} = $param[1];
+        }
+    }
+    
     $self->{human_ancestor_fa} = $self->{human_ancestor_fa} || 'human_ancestor.fa.rz';
     
     return $self;

--- a/src/loftee_utils.py
+++ b/src/loftee_utils.py
@@ -55,8 +55,7 @@ def worst_csq_index(csq_list):
     :param annnotation:
     :return most_severe_consequence_index:
     """
-    csqs = [csq_order_dict[ann] for ann in csq_list if ann in csq_order_dict]
-    return min()
+    return min([csq_order_dict[ann] for ann in csq_list])
 
 
 def worst_csq_from_list(csq_list):

--- a/src/loftee_utils.py
+++ b/src/loftee_utils.py
@@ -17,6 +17,7 @@ csq_order = ["transcript_ablation",
 "missense_variant",
 "splice_region_variant",
 "incomplete_terminal_codon_variant",
+"protein_altering_variant",  # new in v79 - appears to go here?
 "stop_retained_variant",
 "synonymous_variant",
 "coding_sequence_variant",
@@ -45,23 +46,6 @@ csq_order_dict = dict(zip(csq_order, range(len(csq_order))))
 rev_csq_order_dict = dict(zip(range(len(csq_order)), csq_order))
 
 
-def csq_max_compare_lists(ann1, ann2):
-    return rev_csq_order_dict[min(csq_max_list(ann1), csq_max_list(ann2))]
-
-
-def csq_max_vep(ann_list):
-    return rev_csq_order_dict[csq_max_list(ann_list.split('&'))]
-
-
-def csq_max(ann_list):
-    if len(ann_list) == 0: return ''
-    return rev_csq_order_dict[csq_max_list(ann_list)]
-
-
-def csq_max_list(ann_list):
-    return min([csq_order_dict[ann] for ann in ann_list])
-
-
 def worst_csq_index(csq_list):
     """
     Input list of consequences (e.g. ['frameshift_variant', 'missense_variant'])
@@ -71,7 +55,8 @@ def worst_csq_index(csq_list):
     :param annnotation:
     :return most_severe_consequence_index:
     """
-    return min([csq_order_dict[ann] for ann in csq_list])
+    csqs = [csq_order_dict[ann] for ann in csq_list if ann in csq_order_dict]
+    return min()
 
 
 def worst_csq_from_list(csq_list):

--- a/src/tableize_vcf.py
+++ b/src/tableize_vcf.py
@@ -57,242 +57,248 @@ def main(args):
     output_header = 'CHROM\tPOS\tREF\tALT'
     if args.add_ucsc_link: output_header += '\tUCSC'
     if args.include_id: output_header += '\tID'
+    if args.original_position: output_header += '\tORIGINAL_POSITION'
     if not args.omit_filter: output_header += '\tFILTER'
 
     raw_ucsc_link = 'http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr%s:%s-%s'
 
     for line in f:
-        line = line.strip()
+        try:
+            line = line.strip()
 
-        # Reading header lines to get VEP and individual arrays
-        if line.startswith('#'):
-            line = line.lstrip('#')
-            if line.startswith('INFO=<ID='):
-                try:
-                    header_metadata = dict([x.split('=', 1) for x in line.split('<')[1].split('>')[0].split(',', 3) if '=' in x])
-                except Exception, e:
-                    print >> sys.stderr, "Malformed header line: %s" % line
+            # Reading header lines to get VEP and individual arrays
+            if line.startswith('#'):
+                line = line.lstrip('#')
+                if line.startswith('INFO=<ID='):
+                    try:
+                        header_metadata = dict([x.split('=', 1) for x in line.split('<')[1].split('>')[0].split(',', 3) if '=' in x])
+                    except Exception, e:
+                        print >> sys.stderr, "Malformed header line: %s" % line
+                        sys.exit(1)
+                    info_from_header[header_metadata['ID']] = header_metadata
+                if 'ID=CSQ' in line:
+                    vep_field_names = line.split('Format: ')[-1].strip('">').split('|')
+                    vep_info_from_header = dict(zip(vep_field_names, range(len(vep_field_names))))
+                if line.startswith('CHROM'):
+                    header = line.split()
+                    header = dict(zip(header, range(len(header))))
+                    if args.options:
+                        print >> sys.stderr, "######### OPTIONS FOR INFO #########"
+                        for info in info_from_header:
+                            print >> sys.stderr, '%s\t%s' % (info, info_from_header[info]['Description'])
+                        if vep_field_names is not None:
+                            print >> sys.stderr, "######### OPTIONS FOR VEP_INFO #########"
+                            print >> sys.stderr, '\n'.join(vep_field_names)
+                        sys.exit(0)
+                continue
+
+            if len(desired_vep_info) > 0:
+                if vep_field_names is None:
+                    print >> sys.stderr, "VEP info requested, but VCF file does not have a VEP header line. Exiting."
                     sys.exit(1)
-                info_from_header[header_metadata['ID']] = header_metadata
-            if 'ID=CSQ' in line:
-                vep_field_names = line.split('Format: ')[-1].strip('">').split('|')
-                vep_info_from_header = dict(zip(vep_field_names, range(len(vep_field_names))))
-            if line.startswith('CHROM'):
-                header = line.split()
-                header = dict(zip(header, range(len(header))))
-                if args.options:
-                    print >> sys.stderr, "######### OPTIONS FOR INFO #########"
-                    for info in info_from_header:
-                        print >> sys.stderr, '%s\t%s' % (info, info_from_header[info]['Description'])
-                    if vep_field_names is not None:
-                        print >> sys.stderr, "######### OPTIONS FOR VEP_INFO #########"
-                        print >> sys.stderr, '\n'.join(vep_field_names)
-                    sys.exit(0)
-            continue
+                if 'ALLELE_NUM' not in vep_info_from_header:
+                    print >> sys.stderr, "VEP output does not have ALLELE_NUM which is required for extraction. Please re-run VEP with --allele_number. Exiting."
+                    sys.exit(1)
 
-        if len(desired_vep_info) > 0:
-            if vep_field_names is None:
-                print >> sys.stderr, "VEP info requested, but VCF file does not have a VEP header line. Exiting."
-                sys.exit(1)
-            if 'ALLELE_NUM' not in vep_info_from_header:
-                print >> sys.stderr, "VEP output does not have ALLELE_NUM which is required for extraction. Please re-run VEP with --allele_number. Exiting."
+            if header is None:
+                print >> sys.stderr, "VCF file does not have a header line (CHROM POS etc.). Exiting."
                 sys.exit(1)
 
-        if header is None:
-            print >> sys.stderr, "VCF file does not have a header line (CHROM POS etc.). Exiting."
-            sys.exit(1)
-
-        if not started:
-            # Allowing entries even if not found in the header line, with some caveats
-            original_desired_info = copy.deepcopy(desired_info)
-            desired_info = []
-            any_missing = 0
-            for info in original_desired_info:
-                if info in info_from_header:
-                    print >> sys.stderr, 'SUCCESS: Found %s: %s' % (info, info_from_header[info]['Description'])
-                    desired_info.append(info)
-                else:
-                    matches = 0
-                    for header_record in info_from_header:
-                        if re.search('^%s$' % info, header_record):
-                            matches += 1
-                            desired_info.append(header_record)
-                            print >> sys.stderr, 'SUCCESS: Found %s (matching %s): %s' % (header_record, info, info_from_header[header_record]['Description'])
-                    if not matches:
-                        print >> sys.stderr, 'WARNING: Did not find %s in header.' % info
-                        any_missing += 1
-                        desired_info.append(info)
-
-            # Only allowing entries in VEP header.
-            original_desired_vep_info = copy.deepcopy(desired_vep_info)
-            desired_vep_info = []
-            for info in original_desired_vep_info:
-                if info in vep_info_from_header:
-                    desired_vep_info.append(info)
-                    print >> sys.stderr, 'SUCCESS: Found %s' % info
-                else:
-                    matches = 0
-                    for header_record in vep_info_from_header:
-                        if re.search('^%s$' % info, header_record):
-                            matches += 1
-                            desired_vep_info.append(header_record)
-                            print >> sys.stderr, 'SUCCESS: Found %s (matching %s)' % (header_record, info)
-                    if not matches:
-                        print >> sys.stderr, 'WARNING: Did not find %s in VEP header. Not including from here on out.' % info
-                        any_missing += 1
-
-            # Getting info from individuals
-            original_desired_sample_info = copy.deepcopy(desired_sample_info)
-            desired_sample_info = []
-            if len(original_desired_sample_info) > 0:
-                if 'FORMAT' not in header:
-                    print >> sys.stderr, 'WARNING: Did not find FORMAT in header line, will not be extracting any SAMPLE.FORMATs'
-                else:
-                    for info in original_desired_sample_info:
-                        sample_format = info.split('.')
-                        if len(sample_format) != 2:
-                            print >> sys.stderr, 'WARNING: %s is not a SAMPLE.FORMAT designation' % sample_format
-                        else:
-                            sample, format = sample_format
-                            if sample in header:
-                                print >> sys.stderr, 'SUCCESS: Found sample %s in header' % sample
-                                desired_sample_info.append(info)
-                            else:
-                                print >> sys.stderr, 'WARNING: Sample %s not found in header' % sample
-
-            # Warnings/errors for missing data
-            if any_missing: print >> sys.stderr, 'WARNING: At least one INFO line requested was not found. Continuing, but results may be off.'
-            if len(desired_info) + len(desired_vep_info) + len(desired_sample_info) == 0:
-                print >> sys.stderr, 'No fields left in requested info/VEP info. Exiting.'
-                sys.exit(1)
-            if args.lof_only and 'LoF' not in desired_vep_info:
-                print >> sys.stderr, '--lof_only was used, but no LoF tag found in VEP field. Exiting.'
-                sys.exit(1)
-
-            # Ready to go.
-            output_header += '\t' + '\t'.join(desired_info)
-            if len(desired_vep_info) > 0: output_header += '\t' + '\t'.join(desired_vep_info)
-            if len(desired_sample_info) > 0: output_header += '\t' + '\t'.join(desired_sample_info)
-            print >> g, output_header
-            started = True
-
-        # Pull out annotation info from INFO and ALT fields
-        fields = line.split('\t')
-        info_field = dict([(x.split('=', 1)) if '=' in x else (x, x) for x in re.split(';(?=\w)', fields[header['INFO']])])
-
-        if args.only_pass and fields[header['FILTER']] != 'PASS': continue
-        alts = fields[header['ALT']].split(',')
-        if args.biallelic_only and len(alts) > 1: continue
-
-        # Only get VEP info if requested
-        if len(desired_vep_info) > 0:
-            if 'CSQ' in info_field:
-                # if statement in list comp below is a fix for VEP's occasional introduction of a semi-colon into the CSQ.
-                # Can be removed once that is completely fixed.
-                annotations = [dict(zip(vep_field_names, x.split('|'))) for x in info_field['CSQ'].split(',') if len(vep_field_names) == len(x.split('|'))]
-                if args.lof_only: annotations = [x for x in annotations if x['LoF'] == 'HC']
-                if args.canonical_only: annotations = [x for x in annotations if x['CANONICAL'] == 'YES']
-            else:
-                annotations = []
-            if args.lof_only and len(annotations) == 0: continue
-            if args.canonical_only and len(annotations) == 0: continue
-
-        if 'FORMAT' in header:
-            format_fields_list = fields[header['FORMAT']].split(':')
-            format_fields = dict(zip(format_fields_list, range(len(format_fields_list))))
-
-        for index, alt in enumerate(alts):
-            # Get site data
-            if not args.do_not_minrep and get_minimal_representation is not None:
-                new_pos, new_ref, new_alt = get_minimal_representation(fields[header['POS']], fields[header['REF']], alt)
-                if args.snps_only and (len(new_ref) != 1 or len(new_alt) != 1): continue
-                output = [fields[header['CHROM']], str(new_pos), new_ref, new_alt]
-            else:
-                if args.snps_only and (len(fields[header['REF']]) != 1 or len(alt) != 1): continue
-                output = [fields[header['CHROM']], fields[header['POS']], fields[header['REF']], alt]
-
-            ucsc_link = raw_ucsc_link % (output[0], int(output[1]) - args.ucsc_link_window, int(output[1]) + args.ucsc_link_window)
-            if args.add_ucsc_link: output.append(ucsc_link)
-            if args.include_id: output.append(fields[header['ID']])
-            if not args.omit_filter: output.append(fields[header['FILTER']])
-
-            # Get data from INFO field
-            for info in desired_info:
-                if info in info_field:
+            if not started:
+                # Allowing entries even if not found in the header line, with some caveats
+                original_desired_info = copy.deepcopy(desired_info)
+                desired_info = []
+                any_missing = 0
+                for info in original_desired_info:
                     if info in info_from_header:
-                        if 'Number' in info_from_header[info] and info_from_header[info]['Number'] == 'A':
-                            output.append(info_field[info].split(',')[index])
-                        elif 'Number' in info_from_header[info] and info_from_header[info]['Number'] == '0':
-                            output.append(info)
+                        print >> sys.stderr, 'SUCCESS: Found %s: %s' % (info, info_from_header[info]['Description'])
+                        desired_info.append(info)
+                    else:
+                        matches = 0
+                        for header_record in info_from_header:
+                            if re.search('^%s$' % info, header_record):
+                                matches += 1
+                                desired_info.append(header_record)
+                                print >> sys.stderr, 'SUCCESS: Found %s (matching %s): %s' % (header_record, info, info_from_header[header_record]['Description'])
+                        if not matches:
+                            print >> sys.stderr, 'WARNING: Did not find %s in header.' % info
+                            any_missing += 1
+                            desired_info.append(info)
+
+                # Only allowing entries in VEP header.
+                original_desired_vep_info = copy.deepcopy(desired_vep_info)
+                desired_vep_info = []
+                for info in original_desired_vep_info:
+                    if info in vep_info_from_header:
+                        desired_vep_info.append(info)
+                        print >> sys.stderr, 'SUCCESS: Found %s' % info
+                    else:
+                        matches = 0
+                        for header_record in vep_info_from_header:
+                            if re.search('^%s$' % info, header_record):
+                                matches += 1
+                                desired_vep_info.append(header_record)
+                                print >> sys.stderr, 'SUCCESS: Found %s (matching %s)' % (header_record, info)
+                        if not matches:
+                            print >> sys.stderr, 'WARNING: Did not find %s in VEP header. Not including from here on out.' % info
+                            any_missing += 1
+
+                # Getting info from individuals
+                original_desired_sample_info = copy.deepcopy(desired_sample_info)
+                desired_sample_info = []
+                if len(original_desired_sample_info) > 0:
+                    if 'FORMAT' not in header:
+                        print >> sys.stderr, 'WARNING: Did not find FORMAT in header line, will not be extracting any SAMPLE.FORMATs'
+                    else:
+                        for info in original_desired_sample_info:
+                            sample_format = info.split('.')
+                            if len(sample_format) != 2:
+                                print >> sys.stderr, 'WARNING: %s is not a SAMPLE.FORMAT designation' % sample_format
+                            else:
+                                sample, format = sample_format
+                                if sample in header:
+                                    print >> sys.stderr, 'SUCCESS: Found sample %s in header' % sample
+                                    desired_sample_info.append(info)
+                                else:
+                                    print >> sys.stderr, 'WARNING: Sample %s not found in header' % sample
+
+                # Warnings/errors for missing data
+                if any_missing: print >> sys.stderr, 'WARNING: At least one INFO line requested was not found. Continuing, but results may be off.'
+                if len(desired_info) + len(desired_vep_info) + len(desired_sample_info) == 0:
+                    print >> sys.stderr, 'No fields left in requested info/VEP info. Exiting.'
+                    sys.exit(1)
+                if args.lof_only and 'LoF' not in desired_vep_info:
+                    print >> sys.stderr, '--lof_only was used, but no LoF tag found in VEP field. Exiting.'
+                    sys.exit(1)
+
+                # Ready to go.
+                output_header += '\t' + '\t'.join(desired_info)
+                if len(desired_vep_info) > 0: output_header += '\t' + '\t'.join(desired_vep_info)
+                if len(desired_sample_info) > 0: output_header += '\t' + '\t'.join(desired_sample_info)
+                print >> g, output_header
+                started = True
+
+            # Pull out annotation info from INFO and ALT fields
+            fields = line.split('\t')
+            info_field = dict([(x.split('=', 1)) if '=' in x else (x, x) for x in re.split(';(?=\w)', fields[header['INFO']])])
+
+            if args.only_pass and fields[header['FILTER']] != 'PASS': continue
+            alts = fields[header['ALT']].split(',')
+            if args.biallelic_only and len(alts) > 1: continue
+
+            # Only get VEP info if requested
+            if len(desired_vep_info) > 0:
+                if 'CSQ' in info_field:
+                    # if statement in list comp below is a fix for VEP's occasional introduction of a semi-colon into the CSQ.
+                    # Can be removed once that is completely fixed.
+                    annotations = [dict(zip(vep_field_names, x.split('|'))) for x in info_field['CSQ'].split(',') if len(vep_field_names) == len(x.split('|'))]
+                    if args.lof_only: annotations = [x for x in annotations if x['LoF'] == 'HC']
+                    if args.canonical_only: annotations = [x for x in annotations if x['CANONICAL'] == 'YES']
+                else:
+                    annotations = []
+                if args.lof_only and len(annotations) == 0: continue
+                if args.canonical_only and len(annotations) == 0: continue
+
+            if 'FORMAT' in header:
+                format_fields_list = fields[header['FORMAT']].split(':')
+                format_fields = dict(zip(format_fields_list, range(len(format_fields_list))))
+
+            for index, alt in enumerate(alts):
+                # Get site data
+                if not args.do_not_minrep and get_minimal_representation is not None:
+                    new_pos, new_ref, new_alt = get_minimal_representation(fields[header['POS']], fields[header['REF']], alt)
+                    if args.snps_only and (len(new_ref) != 1 or len(new_alt) != 1): continue
+                    output = [fields[header['CHROM']], str(new_pos), new_ref, new_alt]
+                else:
+                    if args.snps_only and (len(fields[header['REF']]) != 1 or len(alt) != 1): continue
+                    output = [fields[header['CHROM']], fields[header['POS']], fields[header['REF']], alt]
+
+                ucsc_link = raw_ucsc_link % (output[0], int(output[1]) - args.ucsc_link_window, int(output[1]) + args.ucsc_link_window)
+                if args.add_ucsc_link: output.append(ucsc_link)
+                if args.include_id: output.append(fields[header['ID']])
+                if args.original_position: output.append(fields[header['POS']])
+                if not args.omit_filter: output.append(fields[header['FILTER']])
+
+                # Get data from INFO field
+                for info in desired_info:
+                    if info in info_field:
+                        if info in info_from_header:
+                            if 'Number' in info_from_header[info] and info_from_header[info]['Number'] == 'A':
+                                output.append(info_field[info].split(',')[index])
+                            elif 'Number' in info_from_header[info] and info_from_header[info]['Number'] == '0':
+                                output.append(info)
+                            else:
+                                output.append(info_field[info])
                         else:
                             output.append(info_field[info])
                     else:
-                        output.append(info_field[info])
-                else:
-                    output.append(missing_string)
+                        output.append(missing_string)
 
-            # Get data out of samples (genotype fields)
-            for sample_format in desired_sample_info:
-                sample, format = sample_format.split('.')
-                if format not in format_fields: continue
-                this_sample_format = dict(zip(format_fields_list, fields[header[sample]].split(':')))
-                if format in this_sample_format:
-                    output.append(this_sample_format[format])
-                else:
-                    output.append(missing_string)
+                # Get data out of samples (genotype fields)
+                for sample_format in desired_sample_info:
+                    sample, format = sample_format.split('.')
+                    if format not in format_fields: continue
+                    this_sample_format = dict(zip(format_fields_list, fields[header[sample]].split(':')))
+                    if format in this_sample_format:
+                        output.append(this_sample_format[format])
+                    else:
+                        output.append(missing_string)
 
-            # Get data out of VEP field
-            if len(desired_vep_info) > 0:
-                # Filter to this allele
-                this_alt_annotations = [x for x in annotations if int(x['ALLELE_NUM']) - 1 == index]
-                if args.lof_only and len(this_alt_annotations) == 0: continue
-                if args.canonical_only and len(this_alt_annotations) == 0: continue
+                # Get data out of VEP field
+                if len(desired_vep_info) > 0:
+                    # Filter to this allele
+                    this_alt_annotations = [x for x in annotations if int(x['ALLELE_NUM']) - 1 == index]
+                    if args.lof_only and len(this_alt_annotations) == 0: continue
+                    if args.canonical_only and len(this_alt_annotations) == 0: continue
 
-                if args.split_by_transcript:
-                    for this_alt_transcript_annotation in this_alt_annotations:
-                        new_output = copy.deepcopy(output)
+                    if args.split_by_transcript:
+                        for this_alt_transcript_annotation in this_alt_annotations:
+                            new_output = copy.deepcopy(output)
+                            for info in desired_vep_info:
+                                this_alt_vep_info = this_alt_transcript_annotation[info]
+
+                                # Process options
+                                if not args.all_csqs and info == 'Consequence': this_alt_vep_info = worst_csq_from_csq(this_alt_vep_info)
+                                if args.simplify_gtex and info == 'TissueExpression':
+                                    # Converting from tissue1:value1&tissue2:value2 to [tissue1, tissue2]
+                                    this_alt_vep_info = set([y.split(':')[0] for y in this_alt_vep_info.split('&')])
+                                    this_alt_vep_info = ','.join(this_alt_vep_info)
+
+                                if this_alt_vep_info == '': this_alt_vep_info = missing_string
+                                new_output.append(this_alt_vep_info)
+                            print >> g, '\t'.join(new_output)
+                    else:
+                        this_alt_annotations = worst_csq_with_vep_all(this_alt_annotations)
                         for info in desired_vep_info:
-                            this_alt_vep_info = this_alt_transcript_annotation[info]
+                            this_alt_vep_info = [x[info] for x in this_alt_annotations if x[info] != '']
 
                             # Process options
-                            if not args.all_csqs and info == 'Consequence': this_alt_vep_info = worst_csq_from_csq(this_alt_vep_info)
+                            if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [csq_max_vep(x) for x in this_alt_vep_info]
                             if args.simplify_gtex and info == 'TissueExpression':
                                 # Converting from tissue1:value1&tissue2:value2 to [tissue1, tissue2]
-                                this_alt_vep_info = set([y.split(':')[0] for y in this_alt_vep_info.split('&')])
-                                this_alt_vep_info = ','.join(this_alt_vep_info)
+                                this_alt_vep_info = set([y.split(':')[0] for x in this_alt_vep_info for y in x.split('&')])
+                            if not args.dont_collapse_annotations:
+                                this_alt_vep_info = set(this_alt_vep_info)
+                                # Collapse consequence further
+                                if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [csq_max(this_alt_vep_info)]
+                                if args.functional_simplify and len(this_alt_vep_info) > 0 and info in ['PolyPhen', 'SIFT']:
+                                    simplified = simplify_polyphen_sift(this_alt_vep_info, info)
+                                    if simplified is not None:
+                                        this_alt_vep_info = ["%s(%s)" % simplified]
 
-                            if this_alt_vep_info == '': this_alt_vep_info = missing_string
-                            new_output.append(this_alt_vep_info)
-                        print >> g, '\t'.join(new_output)
+                            annotation_output = ','.join(this_alt_vep_info)
+                            if annotation_output == '': annotation_output = missing_string
+                            output.append(annotation_output)
+                        print >> g, '\t'.join(output)
                 else:
-                    this_alt_annotations = worst_csq_with_vep_all(this_alt_annotations)
-                    for info in desired_vep_info:
-                        this_alt_vep_info = [x[info] for x in this_alt_annotations if x[info] != '']
-
-                        # Process options
-                        if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [csq_max_vep(x) for x in this_alt_vep_info]
-                        if args.simplify_gtex and info == 'TissueExpression':
-                            # Converting from tissue1:value1&tissue2:value2 to [tissue1, tissue2]
-                            this_alt_vep_info = set([y.split(':')[0] for x in this_alt_vep_info for y in x.split('&')])
-                        if not args.dont_collapse_annotations:
-                            this_alt_vep_info = set(this_alt_vep_info)
-                            # Collapse consequence further
-                            if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [csq_max(this_alt_vep_info)]
-                            if args.functional_simplify and len(this_alt_vep_info) > 0 and info in ['PolyPhen', 'SIFT']:
-                                simplified = simplify_polyphen_sift(this_alt_vep_info, info)
-                                if simplified is not None:
-                                    this_alt_vep_info = ["%s(%s)" % simplified]
-
-                        annotation_output = ','.join(this_alt_vep_info)
-                        if annotation_output == '': annotation_output = missing_string
-                        output.append(annotation_output)
                     print >> g, '\t'.join(output)
-            else:
-                print >> g, '\t'.join(output)
-            chrom = fields[header['CHROM']]
-            if chrom != last_chr:
-                last_chr = chrom
-                print >> sys.stderr, "%s." % chrom,
+                chrom = fields[header['CHROM']]
+                if chrom != last_chr:
+                    last_chr = chrom
+                    print >> sys.stderr, "%s." % chrom,
+        except Exception, e:
+            print >> sys.stderr, "FAILED ON LINE: %s" % line
+            raise e
     print >> sys.stderr
     f.close()
     g.close()
@@ -316,6 +322,7 @@ For VEP info extraction, VEP must be run with --allele_number.'''
     include_arguments = parser.add_argument_group('Fields to include', '(at least one of info, vep_info, or sample_info is required)')
     include_arguments.add_argument('--omit_filter', action='store_true', help='Omit FILTER field from output')
     include_arguments.add_argument('--include_id', action='store_true', help='Include ID field in output')
+    include_arguments.add_argument('--original_position', action='store_true', help='Include original position (pre-minrep)')
     include_arguments.add_argument('--add_ucsc_link', action='store_true', help='Writes link to UCSC for this variant (see ucsc_link_window)')
     include_arguments.add_argument('--info', help='Comma separated list of INFO fields to extract (regex allowed)')
     include_arguments.add_argument('--vep_info', help='Comma separated list of CSQ sub-fields to extract (regex allowed)')

--- a/src/tableize_vcf.py
+++ b/src/tableize_vcf.py
@@ -180,7 +180,7 @@ def main(args):
 
             # Pull out annotation info from INFO and ALT fields
             fields = line.split('\t')
-            info_field = dict([(x.split('=', 1)) if '=' in x else (x, x) for x in re.split(';(?=\w)', fields[header['INFO']])])
+            info_field = dict([(x.split('=', 1)) if '=' in x else (x, x) for x in re.split(';(?=\w)', fields[header['INFO']].replace('"', ''))])
 
             if args.only_pass and fields[header['FILTER']] != 'PASS': continue
             alts = fields[header['ALT']].split(',')

--- a/src/tableize_vcf.py
+++ b/src/tableize_vcf.py
@@ -172,7 +172,7 @@ def main(args):
                     sys.exit(1)
 
                 # Ready to go.
-                output_header += '\t' + '\t'.join(desired_info)
+                if len(desired_info) > 0: output_header += '\t' + '\t'.join(desired_info)
                 if len(desired_vep_info) > 0: output_header += '\t' + '\t'.join(desired_vep_info)
                 if len(desired_sample_info) > 0: output_header += '\t' + '\t'.join(desired_sample_info)
                 print >> g, output_header
@@ -273,14 +273,14 @@ def main(args):
                             this_alt_vep_info = [x[info] for x in this_alt_annotations if x[info] != '']
 
                             # Process options
-                            if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [csq_max_vep(x) for x in this_alt_vep_info]
+                            if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [worst_csq_from_csq(x) for x in this_alt_vep_info]
                             if args.simplify_gtex and info == 'TissueExpression':
                                 # Converting from tissue1:value1&tissue2:value2 to [tissue1, tissue2]
                                 this_alt_vep_info = set([y.split(':')[0] for x in this_alt_vep_info for y in x.split('&')])
                             if not args.dont_collapse_annotations:
                                 this_alt_vep_info = set(this_alt_vep_info)
                                 # Collapse consequence further
-                                if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [csq_max(this_alt_vep_info)]
+                                if not args.all_csqs and info == 'Consequence': this_alt_vep_info = [worst_csq_from_list(this_alt_vep_info)]
                                 if args.functional_simplify and len(this_alt_vep_info) > 0 and info in ['PolyPhen', 'SIFT']:
                                     simplified = simplify_polyphen_sift(this_alt_vep_info, info)
                                     if simplified is not None:

--- a/src/tableize_vcf.py
+++ b/src/tableize_vcf.py
@@ -52,6 +52,7 @@ def main(args):
     vep_field_names = None
     info_from_header = {}
     started = False
+    last_chr = ''
 
     output_header = 'CHROM\tPOS\tREF\tALT'
     if args.add_ucsc_link: output_header += '\tUCSC'
@@ -288,11 +289,19 @@ def main(args):
                     print >> g, '\t'.join(output)
             else:
                 print >> g, '\t'.join(output)
-
+            chrom = fields[header['CHROM']]
+            if chrom != last_chr:
+                last_chr = chrom
+                print >> sys.stderr, "%s." % chrom,
+    print >> sys.stderr
     f.close()
     g.close()
     if bgzip and args.output.endswith('.gz'):
-        subprocess.check_output(['tabix', '-p', 'vcf', args.output])
+        try:
+            subprocess.check_output(['tabix', '-p', 'vcf', args.output])
+        except Exception, e:
+            print >> sys.stderr, "WARNING: Tabix of table failed - perhaps original VCF was out of order, or minrepping put this out of order."
+    print >> sys.stderr, "Done!"
 
 if __name__ == '__main__':
     INFO = '''Parses VCF to extract data from INFO field, VEP annotation (CSQ from inside INFO field), or sample info.

--- a/src/tableize_vcf.py
+++ b/src/tableize_vcf.py
@@ -288,7 +288,7 @@ def main(args):
 
     f.close()
     g.close()
-    if bgzip:
+    if bgzip and args.output.endswith('.gz'):
         subprocess.check_output(['tabix', '-p', 'vcf', args.output])
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix ancestral alleles so that when the ancestral allele does not match ref or alt, it is set to NA rather than False (indicates that we know the answer).