### PR TITLE
Skip calculation of 50_BP_RULE and add NO_EXON_NUMBER flag if framesh…

### DIFF
--- a/LoF.pm
+++ b/LoF.pm
@@ -260,11 +260,16 @@ sub run {
         push(@info, 'BP_DIST:' . $dist);
         push(@info, 'PERCENTILE:' . $lof_percentile);
 
-        my $last_exon_length = get_last_exon_coding_length($tv);
-        my $d = $dist - $last_exon_length;
-        push(@info, 'DIST_FROM_LAST_EXON:' . $d);
-        push(@info, '50_BP_RULE:' . ($d <= 50 ? 'FAIL' : 'PASS'));
-        push(@filters, 'END_TRUNC') if ($d <= 50) & ($gerp_dist <= 180);
+        if ($tv->exon_number){
+            my $last_exon_length = get_last_exon_coding_length($tv);
+            my $d = $dist - $last_exon_length;
+            push(@info, 'DIST_FROM_LAST_EXON:' . $d);
+            push(@info, '50_BP_RULE:' . ($d <= 50 ? 'FAIL' : 'PASS'));
+            push(@filters, 'END_TRUNC') if ($d <= 50) & ($gerp_dist <= 180);
+        }
+        else {
+            push(@flags, 'NO_EXON_NUMBER');
+        }
     }
 
     # Filter out - exonic

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For stop-gained and frameshift variants, LOFTEE flags:
 
 -   Variants in genes with only a single exon
 -   Variants in exons that do not have the evolutionary signature of a protein-coding gene based on PhyloCSF
+-   Variants where no exon number is indicated (apparently because the variant overlaps an intron)
 
 For splice-site variants, LOFTEE flags:
 


### PR DESCRIPTION
…ift or stop_gain variant doesn't have an exon number listed (usually combined with intronic annotation). #35 and #50

I believe this patch fixes the issue.  I tested this and it doesn't report the "uninitialized value in split" error message anymore.  I also decided to add a flag "NO_EXON_NUMBER" to alert the user that although this variant includes a 'frameshift' or 'stop_gain' annotation, there is no exon number listed by VEP so this is potentially problematic. 