### PR TITLE
fix: use BioPerl instead of Bio::Perl if the latter is not available

### DIFF
--- a/LoF.pm
+++ b/LoF.pm
@@ -43,7 +43,12 @@ use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
 use DBI;
 
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
-use Bio::Perl;
+BEGIN {
+    unless (eval "use Bio::Perl; 1") {
+        warn "couldn't use Bio::Perl. Trying BioPerl instead...";
+        use BioPerl;
+    }
+}
 use List::Util qw(sum);
 
 sub get_header_info {

--- a/ancestral.pm
+++ b/ancestral.pm
@@ -27,7 +27,13 @@ use warnings;
 
 use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
-use Bio::Perl;
+
+BEGIN {
+    unless (eval "use Bio::Perl; 1") {
+        warn "couldn't use Bio::Perl. Trying BioPerl instead...";
+        use BioPerl;
+    }
+}
 
 sub get_header_info {
     return {

--- a/context.pm
+++ b/context.pm
@@ -27,7 +27,12 @@ use warnings;
 
 use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
-use Bio::Perl;
+BEGIN {
+    unless (eval "use Bio::Perl; 1") {
+        warn "couldn't use Bio::Perl. Trying BioPerl instead...";
+        use BioPerl;
+    }
+}
 
 sub get_header_info {
     return {


### PR DESCRIPTION
Conda has the `perl-bioperl` package which needs to be used by `use BioPerl` instead of `use Bio::Perl`.
This PR makes Loftee compatible with both modules.